### PR TITLE
randnum.c: cleanup after CVE-2013-4442 fix

### DIFF
--- a/randnum.c
+++ b/randnum.c
@@ -18,20 +18,13 @@
 
 #include "pwgen.h"
 
-#ifdef HAVE_DRAND48
-extern double drand48(void);
-#endif
-
 static int get_random_fd(void);
 
-/* Borrowed/adapted from e2fsprogs's UUID generation code */
 static int get_random_fd()
 {
-	struct timeval	tv;
 	static int	fd = -2;
 
 	if (fd == -2) {
-		gettimeofday(&tv, 0);
 		fd = open("/dev/urandom", O_RDONLY);
 		if (fd == -1)
 			fd = open("/dev/random", O_RDONLY | O_NONBLOCK);


### PR DESCRIPTION
Get rid of 2 left-overs from commit ccda6f21 and in addition remove a misleading comment.

Signed-off-by: Toralf Förster <toralf.foerster@gmx.de>