### PR TITLE
Fix an old bug and add options to include and enforce additional characters

### DIFF
--- a/pw_phonemes.c
+++ b/pw_phonemes.c
@@ -56,7 +56,7 @@ struct pw_element elements[] = {
 
 #define NUM_ELEMENTS (sizeof(elements) / sizeof (struct pw_element))
 
-void pw_phonemes(char *buf, int size, int pw_flags, char *remove)
+void pw_phonemes(char *buf, int size, int pw_flags, char *add, char *remove)
 {
 	int		c, i, len, flags, feature_flags;
 	int		prev, should_be, first;

--- a/pw_phonemes.c
+++ b/pw_phonemes.c
@@ -56,7 +56,7 @@ struct pw_element elements[] = {
 
 #define NUM_ELEMENTS (sizeof(elements) / sizeof (struct pw_element))
 
-void pw_phonemes(char *buf, int size, int pw_flags, char *add, char *remove)
+void pw_phonemes(char *buf, int size, int pw_flags, char *add, char *remove, char *force)
 {
 	int		c, i, len, flags, feature_flags;
 	int		prev, should_be, first;

--- a/pw_rand.c
+++ b/pw_rand.c
@@ -35,6 +35,24 @@ static void remove_chars(char *buf, const char *remove)
 	}
 }
 
+static void add_chars(char *buf, const char *add)
+{
+	const char *cp;
+	char *end;
+
+	if (!add)
+		return;
+	end = buf + strlen(buf);
+	for (cp = add; *cp; cp++) {
+		char *r = strchr(buf, *cp);
+
+		if (r != NULL) // skip if already there
+			continue;
+		*end++ = *cp;
+		*end = '\0';
+	}
+}
+
 static int find_chars(char *buf, const char *set)
 {
 	const char *cp;
@@ -45,7 +63,7 @@ static int find_chars(char *buf, const char *set)
 	return 0;
 }
 
-void pw_rand(char *buf, int size, int pw_flags, char *remove)
+void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove)
 {
 	char		ch, *chars, *wchars;
 	int		i, len, feature_flags;
@@ -60,6 +78,9 @@ void pw_rand(char *buf, int size, int pw_flags, char *remove)
 	len += strlen(pw_lowers);
 	if (pw_flags & PW_SYMBOLS) {
 		len += strlen(pw_symbols);
+	}
+	if (add) {
+		len += strlen(add);
 	}
         chars = malloc(len+1);
         if (!chars) {
@@ -80,12 +101,13 @@ void pw_rand(char *buf, int size, int pw_flags, char *remove)
 	if (pw_flags & PW_SYMBOLS) {
 		strcpy(wchars, pw_symbols);
 	}
-	if (remove) {
+	if (add || remove) {
 		if (pw_flags & PW_AMBIGUOUS)
 			remove_chars(chars, pw_ambiguous);
 		if (pw_flags & PW_NO_VOWELS)
 			remove_chars(chars, pw_vowels);
 		remove_chars(chars, remove);
+		add_chars(chars, add); // Override preceding removals
 		if ((pw_flags & PW_DIGITS) &&
 		    !find_chars(chars, pw_digits)) {
 			fprintf(stderr,

--- a/pw_rand.c
+++ b/pw_rand.c
@@ -63,7 +63,7 @@ static int find_chars(char *buf, const char *set)
 	return 0;
 }
 
-void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove)
+void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove, char *force)
 {
 	char		ch, *chars, *wchars;
 	int		i, len, feature_flags;
@@ -81,6 +81,9 @@ void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove)
 	}
 	if (add) {
 		len += strlen(add);
+	}
+	if (force) {
+		len += strlen(force);
 	}
         chars = malloc(len+1);
         if (!chars) {
@@ -101,13 +104,14 @@ void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove)
 	if (pw_flags & PW_SYMBOLS) {
 		strcpy(wchars, pw_symbols);
 	}
-	if (add || remove) {
+	if (add || remove || force) {
 		if (pw_flags & PW_AMBIGUOUS)
 			remove_chars(chars, pw_ambiguous);
 		if (pw_flags & PW_NO_VOWELS)
 			remove_chars(chars, pw_vowels);
 		remove_chars(chars, remove);
 		add_chars(chars, add); // Override preceding removals
+		add_chars(chars, force);
 		if ((pw_flags & PW_DIGITS) &&
 		    !find_chars(chars, pw_digits)) {
 			fprintf(stderr,
@@ -157,6 +161,8 @@ try_again:
 	if (feature_flags & (PW_UPPERS | PW_DIGITS | PW_SYMBOLS))
 		goto try_again;
 	buf[size] = 0;
+	if (force && !strpbrk(buf, force))
+		goto try_again;
 	free(chars);
 	return;
 }	

--- a/pw_rand.c
+++ b/pw_rand.c
@@ -63,6 +63,16 @@ static int find_chars(char *buf, const char *set)
 	return 0;
 }
 
+static int find_all_chars(char *buf, const char *set)
+{
+	const char *cp;
+
+	for (cp = set; *cp; cp++)
+		if (!strchr(buf, *cp))
+			return 0;
+	return 1;
+}
+
 void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove, char *force)
 {
 	char		ch, *chars, *wchars;
@@ -161,7 +171,7 @@ try_again:
 	if (feature_flags & (PW_UPPERS | PW_DIGITS | PW_SYMBOLS))
 		goto try_again;
 	buf[size] = 0;
-	if (force && !strpbrk(buf, force))
+	if (force && !find_all_chars(buf, force))
 		goto try_again;
 	free(chars);
 	return;

--- a/pwgen.c
+++ b/pwgen.c
@@ -35,6 +35,7 @@ struct option pwgen_options[] = {
 	{ "numerals", no_argument, 0, 'n'},
 	{ "symbols", no_argument, 0, 'y'},
 	{ "num-passwords", required_argument, 0, 'N'},
+	{ "add-chars", required_argument, 0, 'j' },
 	{ "remove-chars", required_argument, 0, 'r' },
 	{ "secure", no_argument, 0, 's' },
 	{ "help", no_argument, 0, 'h'},
@@ -47,7 +48,7 @@ struct option pwgen_options[] = {
 };
 #endif
 
-const char *pw_options = "01AaBCcnN:sr:hH:vy";
+const char *pw_options = "01AaBCcnN:sj:r:hH:vy";
 
 static void usage(void)
 {
@@ -67,6 +68,9 @@ static void usage(void)
 	fputs("  -y or --symbols\n", stderr);
 	fputs("\tInclude at least one special symbol in the password\n", 
 	      stderr);
+	fputs("  -j <chars> or --add-chars=<chars>\n", stderr);
+	fputs("\tAdds/joins characters to the set of characters to "
+	      "generate passwords\n", stderr);
 	fputs("  -r <chars> or --remove-chars=<chars>\n", stderr);
 	fputs("\tRemove characters from the set of characters to "
 	      "generate passwords\n", stderr);
@@ -96,8 +100,9 @@ int main(int argc, char **argv)
 	int	c, i;
 	int	num_cols = -1;
 	char	*buf, *tmp;
+	char	*add=NULL;
 	char	*remove=NULL;
-	void	(*pwgen)(char *inbuf, int size, int pw_flags, char *remove);
+	void	(*pwgen)(char *inbuf, int size, int pw_flags, char *add, char *remove);
 
 	pwgen = pw_phonemes;
 	pw_number = pw_random_number;
@@ -160,6 +165,10 @@ int main(int argc, char **argv)
 			pwgen = pw_rand;
 			pwgen_flags |= PW_NO_VOWELS;
 			break;
+		case 'j':
+			add = strdup(optarg);
+			pwgen = pw_rand;
+			break;
 		case 'r':
 			remove = strdup(optarg);
 			pwgen = pw_rand;
@@ -211,7 +220,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 	for (i=0; i < num_pw; i++) {
-		pwgen(buf, pw_length, pwgen_flags, remove);
+		pwgen(buf, pw_length, pwgen_flags, add, remove);
 		if (!do_columns || ((i % num_cols) == (num_cols-1)) ||
 		    (i == (num_pw - 1)))
 			printf("%s\n", buf);
@@ -219,6 +228,7 @@ int main(int argc, char **argv)
 			printf("%s ", buf);
 	}
 	free(buf);
+	free(add);
 	free(remove);
 	return 0;
 }

--- a/pwgen.c
+++ b/pwgen.c
@@ -219,5 +219,6 @@ int main(int argc, char **argv)
 			printf("%s ", buf);
 	}
 	free(buf);
+	free(remove);
 	return 0;
 }

--- a/pwgen.c
+++ b/pwgen.c
@@ -37,6 +37,7 @@ struct option pwgen_options[] = {
 	{ "num-passwords", required_argument, 0, 'N'},
 	{ "add-chars", required_argument, 0, 'j' },
 	{ "remove-chars", required_argument, 0, 'r' },
+	{ "force-chars", required_argument, 0, 'f' },
 	{ "secure", no_argument, 0, 's' },
 	{ "help", no_argument, 0, 'h'},
 	{ "no-numerals", no_argument, 0, '0' },
@@ -48,7 +49,7 @@ struct option pwgen_options[] = {
 };
 #endif
 
-const char *pw_options = "01AaBCcnN:sj:r:hH:vy";
+const char *pw_options = "01AaBCcnN:sj:r:f:hH:vy";
 
 static void usage(void)
 {
@@ -74,6 +75,9 @@ static void usage(void)
 	fputs("  -r <chars> or --remove-chars=<chars>\n", stderr);
 	fputs("\tRemove characters from the set of characters to "
 	      "generate passwords\n", stderr);
+	fputs("  -f <chars> or --force-chars=<chars>\n", stderr);
+	fputs("\tForce the usage of specified characters in generated passwords\n",
+	      stderr);
 	fputs("  -s or --secure\n", stderr);
 	fputs("\tGenerate completely random passwords\n", stderr);
 	fputs("  -B or --ambiguous\n", stderr);
@@ -102,7 +106,8 @@ int main(int argc, char **argv)
 	char	*buf, *tmp;
 	char	*add=NULL;
 	char	*remove=NULL;
-	void	(*pwgen)(char *inbuf, int size, int pw_flags, char *add, char *remove);
+	char	*force=NULL;
+	void	(*pwgen)(char *inbuf, int size, int pw_flags, char *add, char *remove, char *force);
 
 	pwgen = pw_phonemes;
 	pw_number = pw_random_number;
@@ -173,6 +178,10 @@ int main(int argc, char **argv)
 			remove = strdup(optarg);
 			pwgen = pw_rand;
 			break;
+		case 'f':
+			force = strdup(optarg);
+			pwgen = pw_rand;
+			break;
 		case 'h':
 		case '?':
 			usage();
@@ -220,7 +229,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 	for (i=0; i < num_pw; i++) {
-		pwgen(buf, pw_length, pwgen_flags, add, remove);
+		pwgen(buf, pw_length, pwgen_flags, add, remove, force);
 		if (!do_columns || ((i % num_cols) == (num_cols-1)) ||
 		    (i == (num_pw - 1)))
 			printf("%s\n", buf);
@@ -230,5 +239,6 @@ int main(int argc, char **argv)
 	free(buf);
 	free(add);
 	free(remove);
+	free(force);
 	return 0;
 }

--- a/pwgen.h
+++ b/pwgen.h
@@ -38,10 +38,10 @@ extern const char *pw_ambiguous;
 /* Function prototypes */
 
 /* pw_phonemes.c */
-extern void pw_phonemes(char *buf, int size, int pw_flags, char *add, char *remove);
+extern void pw_phonemes(char *buf, int size, int pw_flags, char *add, char *remove, char *force);
 
 /* pw_rand.c */
-extern void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove);
+extern void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove, char *force);
 
 /* randnum.c */
 extern int pw_random_number(int max_num);

--- a/pwgen.h
+++ b/pwgen.h
@@ -38,10 +38,10 @@ extern const char *pw_ambiguous;
 /* Function prototypes */
 
 /* pw_phonemes.c */
-extern void pw_phonemes(char *buf, int size, int pw_flags, char *remove);
+extern void pw_phonemes(char *buf, int size, int pw_flags, char *add, char *remove);
 
 /* pw_rand.c */
-extern void pw_rand(char *buf, int size, int pw_flags, char *remove);
+extern void pw_rand(char *buf, int size, int pw_flags, char *add, char *remove);
 
 /* randnum.c */
 extern int pw_random_number(int max_num);


### PR DESCRIPTION
Hi,
I got annoyed by the need to include at least one symbol character in passwords but didn't want to use just any symbol but specifically `_` because it gets included in double-click selections in my terminal. So I added two options... one simply allows the user to supply a string of characters that should get included in the pool of valid characters (i.e. kind of the reverse of `--remove-chars`). The other one does not only add the characters but also tests if they are included in the resulting password. The latter dramatically increases the runtime up to infinity if conflicting settings are chosen but it does not tinker with the randomness whatsoever (which I think is more important).
I have split the enforcement patch into two: The first does only check if any of the given characters is included at least once in every resulting password. The second one changes that to test that *all* of the characters are included at least once, which is far less likely to happen at random thus increases the runtime a lot more (exponentially in the length of the string AFAICS) but is likely more useful to potential users.

I have not put much thought into refactoring anything (e.g., the prototypes get a bit bloated) but I don't think there is too much to gain.

The patches do not include changes to the manpage yet. I'd like to have some feedback first.
Cheers.

PS: `find_chars` could simply be replaced with `strpbrk` AFAICT.