### PR TITLE
fix overflow in pw_length no longer causing a floating point exception

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
-AC_INIT(pwgen.c)
-AC_PREREQ(2.50)
+AC_INIT
+AC_CONFIG_SRCDIR([pwgen.c])
+AC_PREREQ([2.71])
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_PATH_PROG(MV, mv, mv)
@@ -8,4 +9,5 @@ AC_PATH_PROG(SED, sed, sed)
 AC_PATH_PROG(PERL, perl, perl)
 AC_CHECK_FUNCS(getopt_long)
 AC_CHECK_HEADERS(getopt.h)
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/pw_phonemes.c
+++ b/pw_phonemes.c
@@ -8,6 +8,7 @@
  */
 
 #include <ctype.h>
+#include <stdio.h>
 #include <string.h>
 #include "pwgen.h"
 
@@ -56,9 +57,10 @@ struct pw_element elements[] = {
 
 #define NUM_ELEMENTS (sizeof(elements) / sizeof (struct pw_element))
 
-void pw_phonemes(char *buf, int size, int pw_flags, char *remove)
+void pw_phonemes(char *buf, size_t size, int pw_flags, char *remove)
 {
-	int		c, i, len, flags, feature_flags;
+	size_t		c, i, len;
+	int		flags, feature_flags;
 	int		prev, should_be, first;
 	const char	*str;
 	char		ch, *cp;

--- a/pw_rand.c
+++ b/pw_rand.c
@@ -45,10 +45,11 @@ static int find_chars(char *buf, const char *set)
 	return 0;
 }
 
-void pw_rand(char *buf, int size, int pw_flags, char *remove)
+void pw_rand(char *buf, size_t size, int pw_flags, char *remove)
 {
 	char		ch, *chars, *wchars;
-	int		i, len, feature_flags;
+	size_t		i, len;
+	int		feature_flags;
 
 	len = 0;
 	if (pw_flags & PW_DIGITS) {

--- a/pwgen.c
+++ b/pwgen.c
@@ -23,7 +23,7 @@ int (*pw_number)(int max_num);
 
 /* Program parameters set via getopt */
 
-int	pw_length = 8;
+unsigned int	pw_length = 8;
 int	num_pw = -1;
 int	pwgen_flags = 0;
 int	do_columns = 0;
@@ -198,7 +198,9 @@ int main(int argc, char **argv)
 	}
 	
 	if (do_columns) {
-		num_cols = term_width / (pw_length+1);
+		num_cols = 0;
+		if (pw_length+1 != 0)
+			num_cols = term_width / (pw_length+1);
 		if (num_cols == 0)
 			num_cols = 1;
 	}

--- a/pwgen.c
+++ b/pwgen.c
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
 			if (pw_length <= 1)
 				pwgen_flags &= ~PW_DIGITS;
 		}
-		if (*tmp) {
+		if (*tmp || pw_length+1 == 0) {
 			fprintf(stderr, "Invalid password length: %s\n",
 				argv[optind]);
 			exit(1);

--- a/pwgen.h
+++ b/pwgen.h
@@ -7,6 +7,7 @@
  * License.
  */
 
+#include <stddef.h>
 struct pw_element {
 	const char	*str;
 	int		flags;
@@ -38,10 +39,10 @@ extern const char *pw_ambiguous;
 /* Function prototypes */
 
 /* pw_phonemes.c */
-extern void pw_phonemes(char *buf, int size, int pw_flags, char *remove);
+extern void pw_phonemes(char *buf, size_t size, int pw_flags, char *remove);
 
 /* pw_rand.c */
-extern void pw_rand(char *buf, int size, int pw_flags, char *remove);
+extern void pw_rand(char *buf, size_t size, int pw_flags, char *remove);
 
 /* randnum.c */
 extern int pw_random_number(int max_num);


### PR DESCRIPTION
fixes crash when executing pwgen $(( 2**32-1 ))